### PR TITLE
feat: leave token separators that are not used for selecting a token …

### DIFF
--- a/src/replacement.spec.ts
+++ b/src/replacement.spec.ts
@@ -46,6 +46,19 @@ describe('Token replacement lib', () => {
         );
         expect(result).toEqual(expectedResult);
     });
+    test('Works with colon (:) separator which leaves colon (:) in place if not used for token replacement', () => {
+        const inputString = ":Have: :a :quality: day: :today: please!:";
+        const qualityTokenValue = "good";
+        const expectedResult = ":Have: :a good day: :today: please!:";
+
+        const result = replaceTokens(
+            inputString,
+            {
+                quality: qualityTokenValue,
+            }
+        );
+        expect(result).toEqual(expectedResult);
+    });
     test('Works with custom transformer', () => {
         const inputString = "Have a :quality: day today!";
         const qualityTokenValue = "good";

--- a/src/replacement.ts
+++ b/src/replacement.ts
@@ -95,5 +95,21 @@ export function replaceTokens<T>(
     const updated = split.map(section => {
         return obj[section] ? options.transformer(obj[section]) : section;
     });
-    return updated.join("");
+    
+    // re-add colons if before and after weren't changed
+    let outStr = '';
+    for(let i = 0; i < split.length; i += 1) {
+        // first item
+        if(i === 0) {
+            outStr += updated[i];
+        }else if(split[i - 1] === updated[i - 1] && split[i] === updated[i]) {
+            // subsequent items that were NOT changed, should HAVE leading colon
+            outStr += ':' + updated[i];
+        }else{
+            // subsequent items that WERE changed, should NOT add leading colon
+            outStr += updated[i];
+        }
+    }
+
+    return outStr;
 }


### PR DESCRIPTION
…(i.e. not replaced)